### PR TITLE
Feature/saved covers page

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,12 @@ var formViewPage = document.querySelector('.form-view');
 var makeOwnCoverButton = document.querySelector('.make-new-button');
 var saveCoverButton = document.querySelector('.save-cover-button');
 var homeButton = document.querySelector('.home-button');
+var viewSavedButton = document.querySelector('.view-saved-button');
+var savedViewPage = document.querySelector('.saved-view');
+
+
+// When the Saved Covers view is visible, the “Show New Random Cover” and “Save Cover” buttons should be hidden
+// When the Saved Covers view is visible, the “Home” button should be visible
 
 var savedCovers = [];
 
@@ -16,6 +22,7 @@ var currentCover;
 window.addEventListener('load', generateRandomCover);
 randomCoverButton.addEventListener('click', generateRandomCover);
 makeOwnCoverButton.addEventListener('click', viewMakeOwnForm);
+viewSavedButton.addEventListener('click', viewSavedCovers)
 
 function getRandomIndex(array) {
   return Math.floor(Math.random() * array.length);
@@ -39,4 +46,9 @@ function viewMakeOwnForm() {
   randomCoverButton.classList.add('hidden');
   saveCoverButton.classList.add('hidden');
   homeButton.classList.remove('hidden');
+}
+
+function viewSavedCovers() {
+  savedViewPage.classList.remove('hidden');
+  mainCoverPage.classList.add('hidden');
 }

--- a/src/main.js
+++ b/src/main.js
@@ -12,8 +12,6 @@ var viewSavedButton = document.querySelector('.view-saved-button');
 var savedViewPage = document.querySelector('.saved-view');
 
 
-// When the Saved Covers view is visible, the “Show New Random Cover” and “Save Cover” buttons should be hidden
-// When the Saved Covers view is visible, the “Home” button should be visible
 
 var savedCovers = [];
 
@@ -51,4 +49,7 @@ function viewMakeOwnForm() {
 function viewSavedCovers() {
   savedViewPage.classList.remove('hidden');
   mainCoverPage.classList.add('hidden');
+  randomCoverButton.classList.add('hidden');
+  saveCoverButton.classList.add('hidden');
+  homeButton.classList.remove('hidden');
 }


### PR DESCRIPTION
# Description
_We added a querySelector for viewSavedButton so that we can create an event listener that listens for the click of this button. We also added a querySelector for savedViewPage so that the event handler viewSavedCovers can remove the class hidden so that the saved covers page appears when the saved covers button is clicked._

var viewSavedButton = document.querySelector('.view-saved-button');
var savedViewPage = document.querySelector('.saved-view');

viewSavedButton.addEventListener('click', viewSavedCovers)

_In the viewSavedCovers handler, we also added statements that add the class hidden to the randomCoverButton and savedCoverButton as well as a statement that removes the class hidden from the homeButton. This makes the randomCoverButton and saveCoverButton disappear and the homeButton appear when the viewSavedButton is clicked._

function viewSavedCovers() {
  savedViewPage.classList.remove('hidden');
  mainCoverPage.classList.add('hidden');
  randomCoverButton.classList.add('hidden');
  saveCoverButton.classList.add('hidden');
  homeButton.classList.remove('hidden');
}

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?
- [ ] No
- [x] Yes

_We opened index.html and the console and clicked the viewSavedButton._

# Message for reviewer:

_We added querySelectors for viewSavedButton and savedViewPage. We added an event listener for viewSavedButton that listens for the click of this button. And we added the event handler viewSavedCovers that displays the saved covers page when clicked. This event handler also makes the home page disappear, the randomCoverButton and saveCoverButton disappear, and the homeButton appear._

# Checklist:
- [x] My code has no unused/commented out code
- [x] My code has no console logs
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
