### PR TITLE
Add statement to viewSavedCovers function that adds the class hidden to formViewPage so that the form disappears.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -48,6 +48,7 @@ function viewMakeOwnForm() {
 function viewSavedCovers() {
   savedViewPage.classList.remove('hidden');
   mainCoverPage.classList.add('hidden');
+  formViewPage.classList.add('hidden');
   randomCoverButton.classList.add('hidden');
   saveCoverButton.classList.add('hidden');
   homeButton.classList.remove('hidden');


### PR DESCRIPTION
# Description

_In the viewSavedCovers function, we added a statement that adds the class hidden to the formViewPage when the function hears the click of the viewedSavedButton._

formViewPage.classList.add('hidden');

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?
- [ ] No
- [x] Yes

_We opened index.html and the console and clicked back and forth through the three buttons homeButton, viewSavedButton, and makeOwnCoverButton to see the three pages switch back and forth._

# Message for reviewer:

_The new addition of the statement to the viewSavedCovers function adds the class hidden to formViewPage so that the form disappears when you click the viewSavedButton._

# Checklist:
- [x] My code has no unused/commented out code
- [x] My code has no console logs
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
