### PR TITLE
Feature/delete saved covers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,6 +29,7 @@ viewSavedButton.addEventListener('click', viewSavedCovers);
 homeButton.addEventListener('click', viewHomePage);
 makeMyBookButton.addEventListener('click', displayFormSubmissionCover);
 saveCoverButton.addEventListener('click', addSavedCover);
+savedCoversSection.addEventListener('dblclick', deleteSavedCover);
 
 function getRandomIndex(array) {
   return Math.floor(Math.random() * array.length);
@@ -111,4 +112,10 @@ function displaySavedCovers() {
       <img class="overlay" src="./assets/overlay.png">
       </section> `)
   }
+}
+
+function deleteSavedCover(event) {
+  var closestCover = event.target.closest('.mini-cover');
+
+  //for loop, if savedCovers[i].id === that variable, splice it from the savedCovers array
 }

--- a/src/main.js
+++ b/src/main.js
@@ -116,6 +116,10 @@ function displaySavedCovers() {
 
 function deleteSavedCover(event) {
   var closestCover = event.target.closest('.mini-cover');
-
-  //for loop, if savedCovers[i].id === that variable, splice it from the savedCovers array
+  for (var i = 0; i < savedCovers.length; i++) {
+    if (savedCovers[i].id == closestCover.dataset.id) {
+      savedCovers.splice(i, 1);
+    }
+  viewSavedCovers();
+  }
 }


### PR DESCRIPTION
# Description

_We added an event listener that listens for a double click in the savedCoversSection._

savedCoversSection.addEventListener('dblclick', deleteSavedCover);

_We added the handler deleteSavedCover that declares a variable closestCover assigned to the element that has the mini-cover class that is closest to the double click. We also added a for loop to this function that loops through each element in the savedCovers array and if the id of that element equals the id of the closestCover, that element is spliced out of the array. To summarize, the cover that is double clicked on is removed from the savedCovers array._

function deleteSavedCover(event) {
  var closestCover = event.target.closest('.mini-cover');
  for (var i = 0; i < savedCovers.length; i++) {
    if (savedCovers[i].id == closestCover.dataset.id) {
      savedCovers.splice(i, 1);
    }
  viewSavedCovers();
  }
}

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other, Please explain:

## Has This Been Tested?
- [ ] No
- [x] Yes

_We opened index.html and the console, saved covers, viewed the saved covers, double clicked on a cover and saw the cover disappear without any error messages._

# Message for reviewer:

_Test out adding saved covers and deleted them by double clicking on the cover in the saved covers section._

# Checklist:
- [x] My code has no unused/commented out code
- [x] My code has no console logs
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas